### PR TITLE
Update conf to allow user to overwrite page columns

### DIFF
--- a/wenyuan-campaign/0.1.1/campaign.typ
+++ b/wenyuan-campaign/0.1.1/campaign.typ
@@ -164,9 +164,8 @@
   // ========================
   show outline.entry.where(level: 1): entry => strong(entry)
   show outline: outl => {
-    set page(columns: 1)
-    set heading(level: 1)
-    columns(2, outl)
+    outl
+    pagebreak()
   }
 
   set outline(depth: 3)


### PR DESCRIPTION
I wanted to change the paper size and columns for printing a mini-adventure. Overwriting the page columns worked for the main body, but not for the outline. This setting changes the outline show rule so that its amount of columns changes with the main column setting.

I also removed some lines that did nothing at all